### PR TITLE
modify numpy requirement to be larger than the earliest version possi…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jserpy"
-version = "0.1.0"
+version = "0.1.2"
 authors = [
     {name = "Ron Pick", email = "ronpi1310@gmail.com"},
 ]
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "typing-inspect>=0.9.0",
-    "numpy>=1.26.4",
+    "numpy>=1.13.0",    # First version to include numpy.generic
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-typing-inspect==0.9.0
-numpy==1.26.4


### PR DESCRIPTION
…ble.

+ First version to include numpy.generic is 1.13
+ This way the existing version of numpy in most cases won't be overriden.